### PR TITLE
Crash on 'Delete Message'

### DIFF
--- a/runtime/messages.go
+++ b/runtime/messages.go
@@ -17,9 +17,12 @@ var (
 )
 
 func (c *AppRuntime) renderMessageEvent(msg *slack.MessageEvent) []byte {
-	if msg.SubType == "message_replied" {
-		return []byte("\nTODO: handle replies")
-	} else {
+	switch msg.SubType {
+	case "message_replied":
+		return []byte("\nTODO: handle message-replies")
+	case "message_deleted":
+		return []byte("\n[#333333]a message was deleted.[-]")
+	default:
 		team := c.GetTeam(msg.Team)
 		t := asTime(msg.Timestamp)
 		uname := msg.User


### PR DESCRIPTION
A very simple fix has been added, that will just output a message when a
'message deleted' event is received, all this does, is prevent the whole
thing from crashing.