### PR TITLE
Wrong Binary name

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,6 @@ run: app
 	./${OUT}
 
 clean:
-	-@rm ${OUT} ${OUT}-v*
+	-@rm ${OUT} ${OUT}-*
 
 .PHONY: run server static vet lint


### PR DESCRIPTION
Fixes #20 by changing the name of the binaries deleted on 'make clean'