### PR TITLE
Debug command-line arg

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,9 @@ static: vet lint
 run: app
 	./${OUT}
 
+debug: app
+	./${OUT} -debug
+
 clean:
 	-@rm ${OUT} ${OUT}-*
 

--- a/main.go
+++ b/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"flag"
 	"fmt"
 	"github.com/thorsager/t-slacker/constants"
 	"github.com/thorsager/t-slacker/runtime"
@@ -12,6 +13,7 @@ import (
 var (
 	version = "undefined"
 	appHome string
+	debug   bool
 )
 
 func init() {
@@ -20,12 +22,15 @@ func init() {
 		log.Fatalf("unable to detect current user: %v", err)
 	}
 	appHome = path.Join(usr.HomeDir, "."+constants.Name)
+	flag.BoolVar(&debug, "debug", false, "Enable debug")
+	flag.Parse()
 }
 
 func main() {
-
+	log.Printf("deug=%t", debug)
 	ctx, err := runtime.New(appHome,
-		fmt.Sprintf(" %s %s - %s", constants.Name, version, constants.Url))
+		fmt.Sprintf(" %s %s - %s", constants.Name, version, constants.Url),
+		debug)
 	if err != nil {
 		log.Fatalf("unable to create application runtime: %v", err)
 	}

--- a/runtime/app_context.go
+++ b/runtime/app_context.go
@@ -29,11 +29,12 @@ type AppRuntime struct {
 }
 
 // New Create new AppRuntime
-func New(appHome string, title string) (*AppRuntime, error) {
+func New(appHome string, title string, debug bool) (*AppRuntime, error) {
 	cfg, err := config.Load(path.Join(appHome, "config.json"))
 	if err != nil {
 		return nil, err
 	}
+	cfg.Debug = debug || cfg.Debug
 
 	app := tview.NewApplication()
 	root := tview.NewPages()


### PR DESCRIPTION
the -debug flag has been added to commandline. Setting this flag will
force the enabling of application-debug, regardless of settings in
config.json.