### PR TITLE
Fixing wrong Channel/Group Indicator

### DIFF
--- a/constants/constants.go
+++ b/constants/constants.go
@@ -1,6 +1,9 @@
 package constants
 
 const (
-	Name = "t-slacker"
-	Url  = "https://github.com/thorsager/t-slacker"
+	Name             = "t-slacker"
+	Url              = "https://github.com/thorsager/t-slacker"
+	UserIndicator    = "@"
+	ChannelIndicator = "#"
+	GroupIndicator   = ChannelIndicator
 )

--- a/runtime/app_context.go
+++ b/runtime/app_context.go
@@ -67,19 +67,19 @@ func (c *AppRuntime) AddPane(teamId, conversationId string, show bool) {
 	if err != nil {
 		c.PaneController.GetStatusPane().Logf("ERROR", "unable to locate conversation %s on %s: %v", conversationId, teamId, err)
 	}
-	cname := chnl.Name
+	cname := constants.ChannelIndicator + chnl.Name
 	topic := chnl.Topic.Value
 	if chnl.IsIM {
 		usr, err := t.UserLookup(chnl.User)
 		if err != nil {
-			cname = chnl.ID
-			topic = fmt.Sprintf("Private message with \"<@%s>\"", chnl.ID)
+			cname = constants.UserIndicator + chnl.ID
+			topic = fmt.Sprintf("Private message with \"<%s>\"", cname)
 		} else {
-			cname = usr.Name
-			topic = fmt.Sprintf("Private message with \"%s <@%s>\"", usr.RealName, usr.Name)
+			cname = constants.UserIndicator + usr.Name
+			topic = fmt.Sprintf("Private message with \"%s <%s>\"", usr.RealName, cname)
 		}
 	}
-	p := c.PaneController.AddPane("#"+cname, topic, teamId, chnl.ID, show, c.buildStatusLine)
+	p := c.PaneController.AddPane(cname, topic, teamId, chnl.ID, show, c.buildStatusLine)
 	if tc.History.Fetch {
 		messages, err := t.GetMessages(chnl.ID, tc.History.Size)
 		if err != nil {

--- a/runtime/list_command.go
+++ b/runtime/list_command.go
@@ -46,14 +46,16 @@ func format(c slack.Channel, team *connection.Connection) string {
 }
 
 func formatChannel(c slack.Channel) string {
-	return fmt.Sprintf("#%s %d [%s %d:%d] %s",
+	return fmt.Sprintf("%s%s %d [%s %d:%d] %s",
+		constants.ChannelIndicator,
 		c.Name, c.NumMembers,
 		channelMod(c), c.UnreadCount, c.UnreadCountDisplay,
 		c.Topic.Value)
 }
 
 func formatGroup(i slack.Channel, team *connection.Connection) string {
-	return fmt.Sprintf("#%s %d [%s %d:%d] %s",
+	return fmt.Sprintf("%s%s %d [%s %d:%d] %s",
+		constants.GroupIndicator,
 		i.Name, i.NumMembers,
 		channelMod(i), i.UnreadCount, i.UnreadCountDisplay,
 		i.Topic.Value)


### PR DESCRIPTION
Fixing #32 '@' and '#' is now used the right way in window list. It has
been implemented in a way that the first char of a `pane.Name` will hold
the indicator.
Constants has been introduced to be used for setting and matching for
channel/user