### PR TITLE
Tab-completion of users and channels

### DIFF
--- a/constants/constants.go
+++ b/constants/constants.go
@@ -1,9 +1,17 @@
 package constants
 
 const (
-	Name             = "t-slacker"
-	Url              = "https://github.com/thorsager/t-slacker"
-	UserIndicator    = "@"
-	ChannelIndicator = "#"
-	GroupIndicator   = ChannelIndicator
+	Name = "t-slacker"
+	Url  = "https://github.com/thorsager/t-slacker"
+
+	ConsoleTeamChannelId = "*console"
+
+	UserIndicatorChar = '@'
+	UserIndicator     = string(UserIndicatorChar)
+
+	ChannelIndicatorChar = '#'
+	ChannelIndicator     = string(ChannelIndicatorChar)
+
+	GroupIndicatorChar = ChannelIndicatorChar
+	GroupIndicator     = string(GroupIndicatorChar)
 )

--- a/pane/controller.go
+++ b/pane/controller.go
@@ -17,14 +17,18 @@ type Controller struct {
 	statusUpdate    func()
 	onInput         func(pane *Pane, input string)
 	inputCapture    func(pane *Pane, event *tcell.EventKey) *tcell.EventKey
+	tabCapture      func(pane *Pane, input string) string
 }
 
-func NewController(root *tview.Pages, qudFunc func(func()), oip func(p *Pane, i string), ic func(p *Pane, e *tcell.EventKey) *tcell.EventKey) *Controller {
-	return &Controller{root: root, queueUpdateDraw: qudFunc, onInput: oip, inputCapture: ic}
+func NewController(root *tview.Pages, qudFunc func(func()), oip func(p *Pane, i string),
+	ic func(p *Pane, e *tcell.EventKey) *tcell.EventKey,
+	tc func(p *Pane, input string) string,
+) *Controller {
+	return &Controller{root: root, queueUpdateDraw: qudFunc, onInput: oip, inputCapture: ic, tabCapture: tc}
 }
 
 func (c *Controller) AddPane(name, title, teamId, channelId string, show bool, statusLine func(p *Pane) string) *Pane {
-	pane := newPane(c, name, title, statusLine, c.onInput, c.inputCapture)
+	pane := newPane(c, name, title, statusLine, c.onInput, c.inputCapture, c.tabCapture)
 	pane.TeamId = teamId
 	pane.ChannelId = channelId
 	c.Lock()

--- a/pane/pane.go
+++ b/pane/pane.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"github.com/gdamore/tcell"
 	"github.com/rivo/tview"
-	"strings"
 	"time"
 )
 
@@ -21,6 +20,7 @@ type Pane struct {
 	notify       bool
 	onInput      func(pane *Pane, input string)
 	inputCapture func(pane *Pane, event *tcell.EventKey) *tcell.EventKey
+	tabCapture   func(pane *Pane, event *tcell.EventKey) string
 	statusLine   func(pane *Pane) string
 
 	TeamId    string
@@ -34,7 +34,8 @@ func (p *Pane) appendContent(s string) {
 func newPane(ctrl *Controller, name, title string,
 	sl func(p *Pane) string,
 	oi func(p *Pane, i string),
-	ic func(p *Pane, key *tcell.EventKey) *tcell.EventKey) *Pane {
+	ic func(p *Pane, key *tcell.EventKey) *tcell.EventKey,
+	tc func(pane *Pane, input string) string) *Pane {
 	cp := &Pane{controller: ctrl, name: name, onInput: oi, inputCapture: ic, statusLine: sl}
 
 	cp.content = tview.NewTextView().
@@ -73,16 +74,18 @@ func newPane(ctrl *Controller, name, title string,
 			cp.content.ScrollTo(nor, 0)
 			return nil
 		case tcell.KeyTAB:
-			line := cp.input.GetText()
-			segments := strings.Split(line, " ")
-			ltok := segments[len(segments)-1]
-			if ltok != "" {
-				if ltok[0] == '@' {
-					cp.Logf("DEBUG", "doing user completion from %s", ltok)
-				} else if ltok[0] == '#' {
-					cp.Logf("DEBUG", "doing channel completion from %s", ltok)
-				}
-			}
+			cp.input.SetText(tc(cp, cp.input.GetText()))
+			//line := cp.input.GetText()
+			//segments := strings.Split(line, " ")
+			//ltok := segments[len(segments)-1]
+			//if ltok != "" {
+			//	if ltok[0] == constants.UserIndicatorChar {
+			//		cp.Logf("DEBUG", "doing user completion from %s", ltok)
+			//	} else if ltok[0] == constants.ChannelIndicatorChar {
+			//		cp.Logf("DEBUG", "doing channel completion from %s", ltok)
+			//	}
+			//	cp.input.SetText(line+"<tab>")
+			//}
 			return nil
 		default:
 			return cp.inputCapture(cp, event)

--- a/runtime/join_command.go
+++ b/runtime/join_command.go
@@ -31,7 +31,11 @@ func (c *joinCommand) Execute(ctx *AppRuntime) {
 		c.source.Log(team.Name, "unable to list conversations")
 		return
 	}
-	ch, err := channelByName(c.args[0], cl)
+	name := c.args[0]
+	if name[0] == constants.ChannelIndicatorChar {
+		name = name[1:]
+	}
+	ch, err := channelByName(name, cl)
 	if err != nil {
 		c.source.Logf(team.Name, "%s", err)
 		return

--- a/runtime/list_command.go
+++ b/runtime/list_command.go
@@ -21,7 +21,7 @@ func (c *listCommand) Execute(ctx *AppRuntime) {
 	}
 	if c.source == ctx.PaneController.GetStatusPane() {
 		team := ctx.GetActiveTeam()
-		list, err := team.GetConversations(types...)
+		list, err := team.GetConversationsCaching(types...)
 		if err != nil {
 			ctx.PaneController.GetActive().Logf("ERROR", "unable to fetch channel-list: %v", err)
 		}

--- a/runtime/privmsg_command.go
+++ b/runtime/privmsg_command.go
@@ -24,7 +24,11 @@ func (c *privMsgCommand) Execute(ctx *AppRuntime) {
 		team = ctx.GetTeam(c.source.TeamId)
 	}
 
-	user, err := team.UserLookupByName(c.args[0])
+	name := c.args[0]
+	if name[0] == constants.UserIndicatorChar {
+		name = name[1:]
+	}
+	user, err := team.UserLookupByName(name)
 	if err != nil {
 		c.source.Logf(team.Name, "%s", err)
 		return


### PR DESCRIPTION
It is now possible to do tab-completion on users (prefix @) and on channels(prefix #) in the input line Fixing #13. In the process it was needed to clean up the use of user/channel names which Fixes #3