### PR TITLE
Fixing tab-completion on beginning of line

### DIFF
--- a/runtime/app_context.go
+++ b/runtime/app_context.go
@@ -10,7 +10,6 @@ import (
 	"github.com/thorsager/t-slacker/constants"
 	"github.com/thorsager/t-slacker/pane"
 	"path"
-	"strings"
 	"sync"
 	"time"
 )
@@ -64,56 +63,6 @@ func New(appHome string, title string, debug bool) (*AppRuntime, error) {
 
 	app.SetRoot(root, true)
 	return ctx, nil
-}
-
-func (c *AppRuntime) tabCapture(p *pane.Pane, input string) string {
-	segments := strings.Split(input, " ")
-	ltok := segments[len(segments)-1]
-	if ltok == "" {
-		return input
-	}
-	niToken := ltok[1:]
-	if c.tab.Indicator != ltok[0] || niToken != c.tab.LastReturned {
-		c.tab.Indicator = ltok[0]
-		c.tab.Count = 0
-		c.tab.Token = niToken
-	}
-	if niToken == c.tab.LastReturned {
-		c.tab.Count = c.tab.Count + 1
-	}
-
-	var team *connection.Connection
-	var output string
-	if p.TeamId == constants.ConsoleTeamChannelId {
-		team = c.GetActiveTeam()
-	} else {
-		team = c.GetTeam(p.TeamId)
-	}
-	switch c.tab.Indicator {
-	case constants.UserIndicatorChar:
-		userNames, err := team.FindUserNamesStartingWith(c.tab.Token)
-		if err != nil {
-			output = input
-			break
-		}
-		idx := c.tab.Count % len(userNames)
-		newToken := userNames[idx]
-		output = strings.Join(append(segments[:1], string(c.tab.Indicator)+newToken), " ")
-		c.tab.LastReturned = newToken //store for repeat detection
-	case constants.ChannelIndicatorChar:
-		channelNames, err := team.FindChannelNamesStartingWith(c.tab.Token)
-		if err != nil {
-			output = input
-			break
-		}
-		idx := c.tab.Count % len(channelNames)
-		newToken := channelNames[idx]
-		output = strings.Join(append(segments[:1], string(c.tab.Indicator)+newToken), " ")
-		c.tab.LastReturned = newToken //store for repeat detection
-	default:
-		output = input
-	}
-	return output
 }
 
 func (c *AppRuntime) AddPane(teamId, conversationId string, show bool) {

--- a/runtime/tab_capture.go
+++ b/runtime/tab_capture.go
@@ -1,0 +1,67 @@
+package runtime
+
+import (
+	"github.com/thorsager/t-slacker/connection"
+	"github.com/thorsager/t-slacker/constants"
+	"github.com/thorsager/t-slacker/pane"
+	"strings"
+)
+
+func (c *AppRuntime) tabCapture(p *pane.Pane, input string) string {
+	segments := strings.Split(input, " ")
+	ltok := segments[len(segments)-1]
+	if ltok == "" {
+		return input
+	}
+	niToken := ltok[1:]
+	if c.tab.Indicator != ltok[0] || niToken != c.tab.LastReturned {
+		c.tab.Indicator = ltok[0]
+		c.tab.Count = 0
+		c.tab.Token = niToken
+	}
+	if niToken == c.tab.LastReturned {
+		c.tab.Count = c.tab.Count + 1
+	}
+
+	var team *connection.Connection
+	var output string
+	if p.TeamId == constants.ConsoleTeamChannelId {
+		team = c.GetActiveTeam()
+	} else {
+		team = c.GetTeam(p.TeamId)
+	}
+	switch c.tab.Indicator {
+	case constants.UserIndicatorChar:
+		userNames, err := team.FindUserNamesStartingWith(c.tab.Token)
+		if err != nil || len(userNames) < 1 {
+			output = input
+			break
+		}
+		idx := c.tab.Count % len(userNames)
+		newToken := userNames[idx]
+		output = join(segments, string(c.tab.Indicator)+newToken)
+		c.tab.LastReturned = newToken //store for repeat detection
+	case constants.ChannelIndicatorChar:
+		channelNames, err := team.FindChannelNamesStartingWith(c.tab.Token)
+		if err != nil || len(channelNames) < 1 {
+			output = input
+			break
+		}
+		idx := c.tab.Count % len(channelNames)
+		newToken := channelNames[idx]
+		output = join(segments, string(c.tab.Indicator)+newToken)
+		c.tab.LastReturned = newToken //store for repeat detection
+	default:
+		output = input
+	}
+	return output
+}
+
+func join(segments []string, newToken string) string {
+	var res string
+	if len(segments) > 1 {
+		res = strings.Join(segments[:1], " ")
+		res += " "
+	}
+	return res + newToken
+}


### PR DESCRIPTION
The "artifact" (which was the token used for completion) is not show any
more, also the complete crash on no matching channels or users on
tab-completion has also been fixed.

Also moved the tab_completion method to separate file, for better focus.

closing #37